### PR TITLE
Fix bug temas AiPlanner

### DIFF
--- a/src/components/AIPlanner.tsx
+++ b/src/components/AIPlanner.tsx
@@ -3,11 +3,12 @@ import './AIPlanner.css';
 import { AuthContext } from '../hooks/authContext';
 import { useDatabase } from '../hooks/useDatabase';
 import { type StudyPlanDay } from './Dashboard';
-import { usePlanner } from '../context/PlannerContext';
 
 interface Topic {
   id: string;
   name: string;
+  description?: string;
+  order?: number;
 }
 
 interface Pdf {
@@ -27,6 +28,7 @@ interface Subject {
     date: string;
     type: 'exam' | 'tp' | 'other';
   }[];
+  extractedTopics?: Topic[];
 }
 
 interface StudyPlan {
@@ -64,7 +66,6 @@ interface StudyPlan {
 
 const AIPlanner = () => {
   const { user } = useContext(AuthContext);
-  const { extractedTopics } = usePlanner();
 
   const [topicCounter, setTopicCounter] = useState(1);
   const [generatingPlan, setGeneratingPlan] = useState(false);
@@ -79,6 +80,12 @@ const AIPlanner = () => {
   const [generatedStudyPlan, setGeneratedStudyPlan] = useState<string>('');
   const [nextPlanId, setNextPlanId] = useState(1);
 
+  // currently selected subject object for convenience
+  const selectedSubject = subjects.find(
+    (s) => s.id === selectedSubjectForPlanning,
+  );
+  const subjectTopics: Topic[] = selectedSubject?.extractedTopics ?? [];
+
   const {
     getUserStudyPlans,
     createStudyPlan,
@@ -91,24 +98,36 @@ const AIPlanner = () => {
       if (!user) return;
       try {
         const materials = await getUserMaterials();
+        interface MaterialPartial {
+          id?: string;
+          subjectName?: string;
+          fileName?: string;
+          examDate?: string;
+          color?: string;
+          importantDates?: Subject['importantDates'];
+          extractedTopics?: Topic[];
+        }
+
         const convertedSubjects: Subject[] = materials.map(
-          (material, index) => {
+          (materialRaw: unknown, index) => {
+            const material = materialRaw as MaterialPartial;
             const subjectId = material.id || `subject-${Date.now()}-${index}`;
             return {
               id: subjectId,
               name:
                 material.subjectName ||
-                material.fileName.replace(/\.(pdf|docx|doc)$/i, ''),
+                (material.fileName || '').replace(/\.(pdf|docx|doc)$/i, ''),
               examDate: material.examDate || '',
               color: material.color || '#4285F4',
               pdfs: [
                 {
                   id: 1,
-                  name: material.fileName,
+                  name: material.fileName || 'unknown',
                   size: '0 MB',
                 },
               ],
               importantDates: material.importantDates || [],
+              extractedTopics: material.extractedTopics || [],
             };
           },
         );
@@ -576,58 +595,62 @@ Genera el JSON del plan de estudio:`;
                 </div>
                 {selectedEvent && (
                   <div>
-                    {extractedTopics.length > 0 && (
+                    {subjectTopics.length > 0 && (
                       <div className="form-group">
                         <h4 className="label-heading">
                           🤖 Temas extraídos por IA del PDF (
-                          {extractedTopics.length} temas encontrados):
+                          {subjectTopics.length} temas encontrados):
                         </h4>
                         <div className="topic-list-container">
-                          {extractedTopics.map((extractedTopic, index) => {
-                            const isAlreadyAdded = topics.some(
-                              (t) =>
-                                t.name.toLowerCase() ===
-                                extractedTopic.name.toLowerCase(),
-                            );
-                            return (
-                              <div
-                                key={`planning-topic-${extractedTopic.id || index}`}
-                                className={`topic-item ${isAlreadyAdded ? 'added' : ''}`}
-                                onClick={() => {
-                                  if (!isAlreadyAdded) {
-                                    const newTopic = {
-                                      id: `topic-${selectedSubjectForPlanning}-${topicCounter}`,
-                                      name: extractedTopic.name,
-                                    };
-                                    setTopics([...topics, newTopic]);
-                                    setTopicCounter((prev) => prev + 1);
-                                  }
-                                }}
-                              >
-                                <div>
-                                  <span className="topic-name">
-                                    {index + 1}. {extractedTopic.name}
-                                  </span>
-                                  {extractedTopic.description && (
-                                    <div className="topic-description">
-                                      {extractedTopic.description}
-                                    </div>
-                                  )}
-                                </div>
-                                <button
-                                  className={`topic-add-btn ${isAlreadyAdded ? 'added' : ''}`}
-                                  disabled={isAlreadyAdded}
+                          {subjectTopics.map(
+                            (extractedTopic: Topic, index: number) => {
+                              const isAlreadyAdded = topics.some(
+                                (t) =>
+                                  t.name.toLowerCase() ===
+                                  extractedTopic.name.toLowerCase(),
+                              );
+                              return (
+                                <div
+                                  key={`planning-topic-${extractedTopic.id || index}`}
+                                  className={`topic-item ${isAlreadyAdded ? 'added' : ''}`}
+                                  onClick={() => {
+                                    if (!isAlreadyAdded) {
+                                      const newTopic = {
+                                        id: `topic-${selectedSubjectForPlanning}-${topicCounter}`,
+                                        name: extractedTopic.name,
+                                      };
+                                      setTopics([...topics, newTopic]);
+                                      setTopicCounter((prev) => prev + 1);
+                                    }
+                                  }}
                                 >
-                                  {isAlreadyAdded ? '✓ Agregado' : '+ Agregar'}
-                                </button>
-                              </div>
-                            );
-                          })}
+                                  <div>
+                                    <span className="topic-name">
+                                      {index + 1}. {extractedTopic.name}
+                                    </span>
+                                    {extractedTopic.description && (
+                                      <div className="topic-description">
+                                        {extractedTopic.description}
+                                      </div>
+                                    )}
+                                  </div>
+                                  <button
+                                    className={`topic-add-btn ${isAlreadyAdded ? 'added' : ''}`}
+                                    disabled={isAlreadyAdded}
+                                  >
+                                    {isAlreadyAdded
+                                      ? '✓ Agregado'
+                                      : '+ Agregar'}
+                                  </button>
+                                </div>
+                              );
+                            },
+                          )}
                         </div>
                         <button
                           onClick={() => {
-                            const newTopics = extractedTopics
-                              .filter((extractedTopic) => {
+                            const newTopics = subjectTopics
+                              .filter((extractedTopic: Topic) => {
                                 const isAlreadyAdded = topics.some(
                                   (t) =>
                                     t.name.toLowerCase() ===
@@ -635,7 +658,7 @@ Genera el JSON del plan de estudio:`;
                                 );
                                 return !isAlreadyAdded;
                               })
-                              .map((extractedTopic, index) => ({
+                              .map((extractedTopic: Topic, index: number) => ({
                                 id: `topic-${selectedSubjectForPlanning}-${topicCounter + index}`,
                                 name: extractedTopic.name,
                               }));

--- a/src/components/Subjects.tsx
+++ b/src/components/Subjects.tsx
@@ -39,7 +39,7 @@ interface AnalysisState {
 
 const Subjects: React.FC = () => {
   const { user } = useContext(AuthContext);
-  const { setExtractedTopics } = usePlanner();
+  const { extractedTopics, setExtractedTopics } = usePlanner();
   const {
     loading: dbLoading,
     getUserMaterials,
@@ -169,6 +169,7 @@ const Subjects: React.FC = () => {
           color: selectedColor,
           examDate: importantDates.length > 0 ? importantDates[0].date : '',
           importantDates: importantDates,
+          extractedTopics: extractedTopics || [],
         });
 
         if (materialId) {
@@ -191,6 +192,7 @@ const Subjects: React.FC = () => {
           setSecondPartialDate(null);
           setTpDate(null);
           setOtherDates([]);
+          setExtractedTopics([]); //Borramos los temas extraidos del contexto global para que no se filtren entre materias
           alert('Materia añadida exitosamente y guardada en Firebase!');
         }
       }

--- a/src/hooks/useDatabase.ts
+++ b/src/hooks/useDatabase.ts
@@ -21,6 +21,12 @@ export const useDatabase = () => {
       subjectName: string; // CORREGIDO: Parámetro agregado para el nombre de la materia
       examDate?: string; // CORREGIDO: Parámetro para la fecha del examen
       color?: string; // CORREGIDO: Parámetro para el color de la materia
+      extractedTopics?: Array<{
+        id: string;
+        name: string;
+        description?: string;
+        order: number;
+      }>; //CORREGIDO: Parámetro agregado para los temas extraídos
       importantDates?: Array<{
         name: string;
         date: string;
@@ -41,6 +47,8 @@ export const useDatabase = () => {
         const materialId = await DatabaseService.createMaterial({
           userId: user.uid,
           ...materialData,
+          // Nos aseguramos que los temas extraidos aparezcan si están presentes
+          extractedTopics: materialData.extractedTopics || [],
         });
 
         console.log('✅ Material creado:', materialId);

--- a/src/services/DatabaseService.ts
+++ b/src/services/DatabaseService.ts
@@ -13,6 +13,7 @@ import {
   Timestamp,
 } from 'firebase/firestore';
 import type { User } from 'firebase/auth';
+import type { ExtractedTopic } from './PDFProcessor';
 
 // Interfaces para la estructura de datos
 export interface UserData {
@@ -31,6 +32,7 @@ export interface Material {
   subjectName: string; // CORREGIDO: Campo agregado para preservar el nombre de materia ingresado por el usuario
   examDate?: string; // CORREGIDO: Campo para guardar la fecha del examen
   color?: string; // CORREGIDO: Campo para guardar el color de la materia
+  extractedTopics?: ExtractedTopic[]; // CORREGIDO: Temas extraídos del PDF asociados a la materia
   importantDates?: Array<{
     name: string;
     date: string;
@@ -150,6 +152,8 @@ export class DatabaseService {
 
       const materialData: Material = {
         ...material,
+        // preserve extractedTopics if provided
+        extractedTopics: material.extractedTopics || [],
         createdAt: Timestamp.now(),
         updatedAt: Timestamp.now(),
       };


### PR DESCRIPTION
Ahora los temas extraídos por IA se guardan directamente en la base de datos, asociados a cada material. El AIPlanner muestra los temas correctos según la materia seleccionada. Se eliminó el uso de estado global para los temas y se limpia el buffer temporal después de guardar.
Detalle de componentes y flujo
**PlannerContext.tsx**
Se usa como buffer temporal para los temas extraídos. Ahora se limpia con setExtractedTopics([]) después de guardar un material, evitando que los temas se mezclen entre materias.
**Subjects.tsx**
Al subir un PDF y extraer temas, estos se guardan en el contexto temporal. Al guardar el material, se envían los temas a la base de datos y se limpia el buffer.
**useDatabase.ts**
El método createMaterial ahora acepta y reenvía los temas extraídos **[extractedTopics]** al servicio de base de datos.
**DatabaseService.ts**
El modelo Material incluye el campo **[extractedTopics]**. Al guardar, los temas quedan asociados al material en Firestore.
**AIPlanner.tsx**
Antes usaba el estado global para mostrar temas. Ahora toma los temas desde el material seleccionado, mostrando solo los que corresponden.

