### PR TITLE
Se arreglo el problema de keys duplicadas

### DIFF
--- a/src/components/AIPlanner.tsx
+++ b/src/components/AIPlanner.tsx
@@ -463,8 +463,16 @@ const AIPlanner = () => {
         expanded: false,
       };
 
-      setStudyPlans((prevPlans) => [...prevPlans, newPlan]);
-      setNextPlanId((prev) => prev + 1);
+      // Si el plan ya fue guardado en Firebase (savedPlanId), entonces
+      // ya recargamos la lista `studyPlans` desde el servidor y no
+      // debemos volver a agregarlo localmente (provoca claves duplicadas).
+      if (!savedPlanId) {
+        setStudyPlans((prevPlans) => [...prevPlans, newPlan]);
+        setNextPlanId((prev) => prev + 1);
+      } else {
+        // No incrementamos nextPlanId ni agregamos el plan localmente
+        // porque la lista ya fue actualizada desde Firebase.
+      }
 
       console.log('🎉 Plan de estudio generado y guardado exitosamente');
     } catch (error: unknown) {
@@ -670,14 +678,29 @@ const AIPlanner = () => {
                                 t.name.toLowerCase() ===
                                 extractedTopic.name.toLowerCase(),
                             );
+                            // Key única por tema: combina id de materia, id del tema (o índice) y nombre estandar.
+                            const safeTopicId = extractedTopic.id
+                              ? String(extractedTopic.id)
+                              : `idx-${index}`;
+                            const subjectKeyPart = selectedSubjectForPlanning
+                              ? String(selectedSubjectForPlanning)
+                              : 'no-subject';
+                            const sanitizedName = String(extractedTopic.name)
+                              .replace(/\s+/g, '-')
+                              .replace(/[^a-zA-Z0-9-_]/g, '')
+                              .slice(0, 40);
+
+                            const itemKey = `planning-topic-${subjectKeyPart}-${safeTopicId}-${sanitizedName}`;
+
                             return (
                               <div
-                                key={`planning-topic-${extractedTopic.id || index}`}
+                                key={itemKey}
                                 className={`topic-item ${isAlreadyAdded ? 'added' : ''}`}
                                 onClick={() => {
                                   if (!isAlreadyAdded) {
                                     const newTopic = {
-                                      id: `topic-${selectedSubjectForPlanning}-${topicCounter}`,
+                                      // id único por materia + contador local
+                                      id: `topic-${selectedSubjectForPlanning}-${Date.now()}-${topicCounter}`,
                                       name: extractedTopic.name,
                                     };
                                     setTopics([...topics, newTopic]);
@@ -707,6 +730,7 @@ const AIPlanner = () => {
                         </div>
                         <button
                           onClick={() => {
+                            const timestamp = Date.now();
                             const newTopics = extractedTopics
                               .filter((extractedTopic) => {
                                 const isAlreadyAdded = topics.some(
@@ -716,8 +740,9 @@ const AIPlanner = () => {
                                 );
                                 return !isAlreadyAdded;
                               })
-                              .map((extractedTopic, index) => ({
-                                id: `topic-${selectedSubjectForPlanning}-${topicCounter + index}`,
+                              .map((extractedTopic, idx) => ({
+                                // id único con timestamp para evitar colisiones
+                                id: `topic-${selectedSubjectForPlanning}-${timestamp}-${topicCounter + idx}`,
                                 name: extractedTopic.name,
                               }));
                             setTopics([...topics, ...newTopics]);
@@ -763,7 +788,13 @@ const AIPlanner = () => {
                         <div className="topic-list">
                           {topics.map((topic, index) => (
                             <div
-                              key={`topic-${topic.id || index}`}
+                              // Usar el id del topic si existe (es estable), sino
+                              // un fallback con índice y nombre para mantener unicidad
+                              key={
+                                topic.id
+                                  ? String(topic.id)
+                                  : `topic-fallback-${index}-${String(topic.name).replace(/\s+/g, '-')}`
+                              }
                               className="topic-tag"
                             >
                               <span>{topic.name}</span>


### PR DESCRIPTION
Resumen

Se corrige un warning de React sobre claves duplicadas en la lista de planes/temas y se mejora la generación de keys/ids para temas creados localmente en AIPlanner.
También se simplifica un comentario explicativo en español para mayor claridad.
Qué se cambió

**Archivo modificado:**

- **[AIPlanner.tsx](vscode-file://vscode-app/c:/Users/PCP2/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)**

- Cambios principales:
1. Evitar inserción duplicada de un plan en la UI:
Antes: al crear un plan se empujaba siempre el nuevo plan al estado local studyPlans y además se recargaba la lista desde Firebase → duplicado y warning.
Ahora: si el plan se guardó en Firebase (savedPlanId existe) se recarga la lista desde el servidor y NO se vuelve a agregar localmente el plan (condición: if (!savedPlanId) { ... }).

2. Generación de key/id más robusta para temas extraídos:
Se construye itemKey combinando id de materia, id del tema (o índice) y nombre sanitizado: planning-topic-<subject>-<topicIdOrIndex>-<sanitizedName>.
Al agregar temas manualmente o “Agregar todos”, los ids locales incluyen Date.now() + contador (topic-${subject}-${timestamp}-${counter}) para minimizar colisiones.

3. Comparación anti-duplicados al agregar temas:
Se mantiene la comparación por name (case-insensitive) para evitar agregar varias veces el mismo nombre desde la UI.
(Se propuso y documentó que comparar por id cuando exista sería más robusto; ver recomendaciones.)

4. Simplificación de comentarios en español para mayor legibilidad.

**Por qué (motivo)**
Evitar el warning: "Encountered two children with the same key" de React causado por la inserción local + recarga desde Firebase.
Hacer las keys de los items más únicas y estables para que React gestione el DOM correctamente y evitar inconsistencias del estado local al re-renderizar.